### PR TITLE
Fix `thingList` type to an array in `GetThings` API

### DIFF
--- a/dist/index.d.cts
+++ b/dist/index.d.cts
@@ -950,7 +950,7 @@ type thingInfo$3 = {
     thingList: {
         itemType: Number | 1 | 2 | 3;
         id: string;
-    };
+    }[];
 };
 interface GetThings extends BaseWebAPI {
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -950,7 +950,7 @@ type thingInfo$3 = {
     thingList: {
         itemType: Number | 1 | 2 | 3;
         id: string;
-    };
+    }[];
 };
 interface GetThings extends BaseWebAPI {
 }

--- a/src/web/apis/device/getThings.ts
+++ b/src/web/apis/device/getThings.ts
@@ -4,7 +4,7 @@ export type thingInfo = {
   thingList: {
     itemType: Number | 1 | 2 | 3;
     id: string;
-  };
+  }[];
 };
 
 export interface GetThings extends BaseWebAPI {}


### PR DESCRIPTION
The `thingList` property type was changed from an object to an array of objects. This ensures the API properly handles multiple items in the `thingList` field. All relevant interfaces were updated accordingly.

This change is based on the interface defined here in the documentations https://coolkit-technologies.github.io/eWeLink-API/#/en/APICenterV2?id=get-specified-things-list